### PR TITLE
Replace copy with synchronize for large container files sync

### DIFF
--- a/roles/docker_registry/tasks/images.yml
+++ b/roles/docker_registry/tasks/images.yml
@@ -14,7 +14,7 @@
   file: path=/opt/docker_images state=directory # gluster volume ???
 
 - name: Upload Images
-  copy:
+  synchronize:
     src: "{{ item }}"
     dest: "/opt/docker_images/{{ item|basename }}"
   with_items: '{{ docker_images.stdout_lines | default([]) }}'


### PR DESCRIPTION
Synchronize module fixes issue with memory leaks during using copy module for large files (like docker container images in tar files)